### PR TITLE
Redesign site with a modern look and refreshed content

### DIFF
--- a/themes/hugo-paradigm/assets/scss/theme/sections/features/_features.scss
+++ b/themes/hugo-paradigm/assets/scss/theme/sections/features/_features.scss
@@ -1,0 +1,69 @@
+.features {
+  .features-heading {
+    text-align: center;
+    max-width: 640px;
+    margin: 0 auto 26px auto;
+    p {
+      font-size: 17px;
+    }
+    @include media-breakpoint-up(md) {
+      margin-bottom: 40px;
+    }
+  }
+
+  .feature-card {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    padding: 28px;
+    border-radius: 16px;
+    background-color: var(--color-base);
+    border: 1px solid var(--color-base-offset);
+    box-shadow: 0 1px 2px rgba(11, 28, 51, 0.05), 0 12px 32px -16px rgba(11, 28, 51, 0.12);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+    &:hover {
+      transform: translateY(-4px);
+      border-color: var(--color-primary);
+      box-shadow: 0 2px 4px rgba(11, 28, 51, 0.05), 0 24px 48px -16px rgba(11, 28, 51, 0.2);
+    }
+    h3 {
+      font-size: 20px;
+      margin-bottom: 10px;
+    }
+    p {
+      font-size: 15px;
+      line-height: 1.65;
+      margin-top: 0;
+      margin-bottom: 16px;
+    }
+    .feature-icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 52px;
+      height: 52px;
+      margin-bottom: 18px;
+      border-radius: 14px;
+      font-size: 22px;
+      color: var(--color-primary-text);
+      background-image: linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-offset) 100%);
+      box-shadow: 0 8px 20px -8px rgba(0, 95, 209, 0.5);
+    }
+    .feature-link {
+      margin-top: auto;
+      font-family: var(--font-heading);
+      font-weight: 600;
+      font-size: 15px;
+      &:hover {
+        text-decoration: none;
+        .feature-link-arrow {
+          transform: translateX(4px);
+        }
+      }
+      .feature-link-arrow {
+        display: inline-block;
+        transition: transform 0.15s ease;
+      }
+    }
+  }
+}

--- a/themes/hugo-paradigm/layouts/partials/sections/features/features.html
+++ b/themes/hugo-paradigm/layouts/partials/sections/features/features.html
@@ -1,0 +1,37 @@
+{{ $columns := 4 }}
+{{ if .features.columns }}{{ $columns = .features.columns }}{{ end }}
+
+<div class="features">
+    {{ if or (.features.heading) (.features.text) (.features.eyebrow) }}
+    <div class="row">
+        <div class="col-12">
+            <div class="features-heading">
+                {{ if .features.eyebrow }}<span class="eyebrow">{{ .features.eyebrow }}</span>{{ end }}
+                {{ if .features.heading }}<h2>{{ .features.heading | markdownify }}</h2>{{ end }}
+                {{ if .features.text }}<p>{{ .features.text }}</p>{{ end }}
+            </div>
+        </div>
+    </div>
+    {{ end }}
+
+    <div class="row">
+        {{ range .features.features }}
+        <div class="col-12 col-md-{{ $columns }} mb-1 mt-1 mb-md-2 mt-md-2 d-flex">
+            <div class="feature-card">
+                {{ if .icon }}
+                <div class="feature-icon">
+                    <i class="{{ .icon }}"></i>
+                </div>
+                {{ end }}
+                {{ if .title }}<h3>{{ .title }}</h3>{{ end }}
+                {{ if .text }}<p>{{ .text }}</p>{{ end }}
+                {{ if .url }}
+                <a class="feature-link" href="{{ if .external }}{{ .url }}{{ else }}{{ .url | relURL }}{{ end }}" {{ if .external }}target="_blank" rel="noopener"{{ end }}>
+                    {{ .linkText | default "Learn more" }} <span class="feature-link-arrow">&rarr;</span>
+                </a>
+                {{ end }}
+            </div>
+        </div>
+        {{ end }}
+    </div>
+</div>


### PR DESCRIPTION
## Summary

Modernizes the site's design while keeping the existing blue color scheme, and refreshes content to reflect the current focus (platform engineering + cloud, no longer Mendix consultancy).

### Visual redesign
- New `cinaq` theme entry: **Inter + Space Grotesk** fonts, refined blue palette with navy/soft tones for light and dark mode
- Sticky frosted-glass header, modernized nav and dropdown styling
- Bolder hero typography with a gradient keyword accent and subtle fade-up animation (respects `prefers-reduced-motion`)
- Pill-shaped gradient buttons with hover lift
- Rounded cards with layered shadows and hover states
- Dark navy footer with radial glow; gradient primary strips; new `base-soft`/`navy` strip variants
- New reusable **`features` section template** for inline icon cards (icon + title + text + link defined in front matter)

### Content refresh
- Homepage rebuilt as a full landing page: hero → services feature grid → Low-Ops and MxLint product sections → latest blog posts → contact CTA
- De-emphasized Mendix: removed the broken "Mendix Deployment" button on Services (pointed to a deleted page), updated services/about copy
- Removed leftover hugo-paradigm demo content (`features/`, `partners/`, `custom-page-1/2/3`, demo Products page)
- Fixed stale "Design Websites In Minutes" meta description on the Contact page
- Footer links now point to mxlint.com and github.com/cinaq

### Build fix
The second commit force-adds two new theme files (`_features.scss`, `features.html`) that were silently skipped by `git add` because `themes/hugo-paradigm` is listed in `.gitignore` — this broke the first CI run. Verified via a cold-cache build of a `git archive` of the tree: reproduces the CI failure at the first commit, builds clean (317 pages) with the fix.

**Note:** any future *new* file in `themes/hugo-paradigm` will hit the same `.gitignore` trap; consider removing that ignore entry if theme customization continues.

## Testing
- Built with Hugo extended 0.159.2 (the version pinned in the Makefile)
- Screenshot-verified all key pages (home, services, service detail, blog list, blog article, about, contact) in light mode, dark mode, and mobile (390px) viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2NAPrNa9frYNgQDZJafUj

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2NAPrNa9frYNgQDZJafUj)_