### PR TITLE
Apply Deep Space hero and fix mobile nav clipped by header blur

### DIFF
--- a/themes/hugo-paradigm/assets/scss/theme/_header.scss
+++ b/themes/hugo-paradigm/assets/scss/theme/_header.scss
@@ -10,10 +10,23 @@
   position: sticky;
   top: 0;
   border-bottom: 1px solid var(--color-base-offset);
+  // The blur must live on a pseudo-element: backdrop-filter on .header itself
+  // makes it the containing block for the position:fixed mobile menu inside,
+  // collapsing the menu to header height (empty-looking mobile nav).
   @supports ((backdrop-filter: blur(12px)) and (background-color: color-mix(in srgb, red 50%, transparent))) {
-    background-color: color-mix(in srgb, var(--color-base) 80%, transparent);
-    backdrop-filter: blur(12px) saturate(160%);
-    -webkit-backdrop-filter: blur(12px) saturate(160%);
+    background-color: transparent;
+    &:before {
+      content: '';
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      z-index: -1;
+      background-color: color-mix(in srgb, var(--color-base) 80%, transparent);
+      backdrop-filter: blur(12px) saturate(160%);
+      -webkit-backdrop-filter: blur(12px) saturate(160%);
+    }
   }
   @include media-breakpoint-up(md) {
     padding: 10px 0;
@@ -151,8 +164,9 @@
   border-bottom: none;
   @supports ((backdrop-filter: blur(12px)) and (background-color: color-mix(in srgb, red 50%, transparent))) {
     background-color: transparent;
-    backdrop-filter: none;
-    -webkit-backdrop-filter: none;
+    &:before {
+      display: none;
+    }
   }
   .hamburger {
     color: white;

--- a/themes/hugo-paradigm/assets/scss/theme/_main-menu-mobile.scss
+++ b/themes/hugo-paradigm/assets/scss/theme/_main-menu-mobile.scss
@@ -54,7 +54,7 @@
     }
   }
   &.open {
-    opacity: 0.9;
+    opacity: 0.98;
     visibility: visible;
     height: 100%;
     width: 100%;

--- a/themes/hugo-paradigm/assets/scss/theme/_strip.scss
+++ b/themes/hugo-paradigm/assets/scss/theme/_strip.scss
@@ -64,10 +64,33 @@ $strip-padding: $grid-gutter-width * 3;
   }
 }
 
-// Soft radial glow background for the homepage hero
+// "Deep Space" homepage hero: dark navy with glowing blue radials and a
+// faint dot matrix. Works in both light and dark mode via --color-navy.
 .hero-home {
-  background-color: var(--color-base);
+  background-color: var(--color-navy);
   background-image:
-    radial-gradient(1100px 560px at 85% -10%, rgba(0, 123, 255, 0.14), transparent 60%),
-    radial-gradient(900px 480px at -10% 110%, rgba(25, 80, 143, 0.10), transparent 60%);
+    radial-gradient(rgba(120, 180, 255, 0.10) 1px, transparent 1px),
+    radial-gradient(900px 520px at 82% -15%, rgba(0, 123, 255, 0.4), transparent 62%),
+    radial-gradient(760px 460px at 8% 115%, rgba(61, 155, 255, 0.22), transparent 60%);
+  background-size: 26px 26px, auto, auto;
+  color: #ffffff;
+  .hero-text {
+    color: #ffffff;
+    h1 strong {
+      background-image: linear-gradient(105deg, #66b3ff 0%, #00d4ff 100%);
+    }
+    p {
+      color: rgba(255, 255, 255, 0.78);
+    }
+  }
+  .hero-image img {
+    box-shadow: 0 0 80px rgba(0, 123, 255, 0.35), 0 30px 60px -20px rgba(0, 0, 0, 0.5);
+  }
+  .button-base-text {
+    color: #ffffff !important;
+    border-color: rgba(255, 255, 255, 0.4) !important;
+    &:hover {
+      border-color: #ffffff !important;
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Follow-up to #12 with two changes:

### 🌌 "Deep Space" homepage hero
The homepage hero now uses a dark navy background with glowing blue radial gradients, a faint dot-matrix texture, a cyan gradient accent on the headline keyword, and a soft glow behind the illustration. It uses `--color-navy`, so it adapts cleanly to dark mode (where it blends into the dark page background). The rest of the page stays light, giving the page a dark → light → blue CTA → navy footer rhythm.

### 🐛 Fix: mobile navigation appeared empty
The mobile menu opened but showed no items. Root cause: `backdrop-filter` on the sticky `.header` (added in #12) makes the header the **containing block for `position: fixed` descendants** — and the mobile menu overlay is a fixed element inside the header. Its `height: 100%` collapsed to the 60px header height, and `overflow: hidden` clipped every link out of view.

Fix: the frosted-glass blur now lives on a `.header::before` pseudo-element. Pseudo-elements have no descendants, so the containing-block side effect is gone while the visual effect is identical. Also bumped the open menu overlay opacity 0.9 → 0.98 for readability over the dark hero.

## Testing
Verified with Playwright against a local Hugo build:
- Mobile (390px): menu overlay is full-viewport with all 7 links visible (Low-Ops, MxLint, Services + 2 children, Blog, Newsletter) plus dark-mode toggle; opens and closes correctly
- Desktop: all menu links present; Services dropdown renders on hover
- Homepage screenshot-checked in light mode, dark mode, and mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2NAPrNa9frYNgQDZJafUj

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2NAPrNa9frYNgQDZJafUj)_